### PR TITLE
activerecord: reconnect on StatementInvalid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fleiss (0.4.1)
+    fleiss (0.4.2)
       activejob (>= 6.0)
       activerecord (>= 6.0)
       concurrent-ruby
@@ -104,4 +104,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/fleiss.gemspec
+++ b/fleiss.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'fleiss'
-  s.version       = '0.4.1'
+  s.version       = '0.4.2'
   s.authors       = ['Black Square Media Ltd']
   s.email         = ['info@blacksquaremedia.com']
   s.summary       = %(Minimialist background jobs backed by ActiveJob and ActiveRecord.)

--- a/lib/fleiss/backend/active_record/concern.rb
+++ b/lib/fleiss/backend/active_record/concern.rb
@@ -19,6 +19,9 @@ module Fleiss
         module ClassMethods
           def wrap_perform(&block)
             connection_pool.with_connection(&block)
+          rescue ::ActiveRecord::StatementInvalid
+            ::ActiveRecord::Base.clear_active_connections!
+            raise
           end
 
           # @return [ActiveRecord::Relation] pending scope

--- a/spec/fleiss/backend/active_record_spec.rb
+++ b/spec/fleiss/backend/active_record_spec.rb
@@ -123,4 +123,13 @@ RSpec.describe Fleiss::Backend::ActiveRecord do
     expect(rec.started_at).to be_nil
     expect(rec.scheduled_at).to be_within(2.seconds).of(Time.zone.now)
   end
+
+  it 'reconnects' do
+    expect(::ActiveRecord::Base).to receive(:clear_active_connections!).once.and_return(nil)
+
+    expect do
+      described_class.wrap_perform { raise ::ActiveRecord::StatementInvalid }
+    end
+      .to raise_error(::ActiveRecord::StatementInvalid) # re-raised anyway
+  end
 end


### PR DESCRIPTION
Maybe it would be better to have smth like `Fleiss::Backend::ActiveRecord.wrap_cycle` or so to rescue from ALL the exceptions.

With current approach we have smth like:

```
backend.select_some.to_a # first query, not resqued

backend.wrap_perform { ... } # more queries here, and only these are rescue-d
```

But even this should improve long-running workers, otherwise it's prone to looping with statement invalid exception, especially with PostgreSQL.