### PR TITLE
active record: clear_all_connections on db connection failures

### DIFF
--- a/lib/fleiss/backend/active_record/concern.rb
+++ b/lib/fleiss/backend/active_record/concern.rb
@@ -20,7 +20,7 @@ module Fleiss
           def wrap_perform(&block)
             connection_pool.with_connection(&block)
           rescue ::ActiveRecord::StatementInvalid
-            ::ActiveRecord::Base.clear_active_connections!
+            ::ActiveRecord::Base.clear_all_connections!
             raise
           end
 

--- a/spec/fleiss/backend/active_record_spec.rb
+++ b/spec/fleiss/backend/active_record_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Fleiss::Backend::ActiveRecord do
   end
 
   it 'reconnects' do
-    expect(::ActiveRecord::Base).to receive(:clear_active_connections!).once.and_return(nil)
+    expect(::ActiveRecord::Base).to receive(:clear_all_connections!).once.and_return(nil)
 
     expect do
       described_class.wrap_perform { raise ::ActiveRecord::StatementInvalid }


### PR DESCRIPTION
https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/ConnectionHandler.html#method-i-clear_active_connections-21

> Returns any connections in use by the current thread back to the pool, and also returns connections to the pool cached by threads that are no longer alive.

Connection is retrieved explicitly here, so there should not be any "runaway"
connections.
`clear_active_connections!` makes sense to be done after every processing
cycle, but not (only) on errors.

But `clear_all_connections!` is suitable to be done on database
connection failures, as it explicitly empties the pool (disconnects
every pooled connection).

This should solve (or at least improve) issue when Fleiss is stuck in
exception loop after DB blips.